### PR TITLE
chore: update Redis port in RedisConfig

### DIFF
--- a/src/main/kotlin/com/flowery/flowerywebsocket/config/RedisConfig.kt
+++ b/src/main/kotlin/com/flowery/flowerywebsocket/config/RedisConfig.kt
@@ -13,7 +13,7 @@ class RedisConfig {
 
     @Bean
     fun redisConnectionFactory(): RedisConnectionFactory {
-        return LettuceConnectionFactory("localhost", 6379) // local에서 애플리케이션 실행 시
+        return LettuceConnectionFactory("localhost", 6380) // local에서 애플리케이션 실행 시
         //return LettuceConnectionFactory("wsredis", 6379) // wsredis: Docker Compose 네트워크에서 컨테이너 이름
     }
     @Bean


### PR DESCRIPTION
Docker Compose로 컨테이너 생성 시 기존 Redis와의 포트 충돌을 방지하기 위해 wsredis 컨테이너를 포트 6780에 매핑하였습니다.